### PR TITLE
fix: support Matplotlib 3.11 colormap API

### DIFF
--- a/Python雷达可视化工具示例/radarViewer.py
+++ b/Python雷达可视化工具示例/radarViewer.py
@@ -282,7 +282,7 @@ class RadarCluster:
         self.enable_clustering = BooleanVar(value=False)
         self.eps = DoubleVar(value=2.0)  # 聚类半径
         self.min_samples = IntVar(value=2)  # 最小样本数
-        self.cluster_colors = plt.cm.get_cmap('tab10', 20)  # 聚类颜色映射
+        self.cluster_colors = plt.get_cmap('tab10', 20)  # 聚类颜色映射
 
     def cluster(self, df):
         if not self.enable_clustering.get() or df.empty or DBSCAN is None:

--- a/Python雷达可视化工具示例/tests/test_matplotlib_compatibility.py
+++ b/Python雷达可视化工具示例/tests/test_matplotlib_compatibility.py
@@ -1,0 +1,40 @@
+"""验证 Python 可视化工具与当前 Matplotlib API 的兼容性。"""
+
+import importlib.util
+import os
+from pathlib import Path
+import sys
+import tkinter as tk
+import types
+import unittest
+
+
+os.environ.setdefault("MPLBACKEND", "Agg")
+
+
+def load_radar_viewer():
+    """在无图形窗口的测试环境中加载示例脚本。"""
+    fake_backend = types.ModuleType("matplotlib.backends.backend_tkagg")
+    fake_backend.FigureCanvasTkAgg = object
+    sys.modules["matplotlib.backends.backend_tkagg"] = fake_backend
+
+    script_path = Path(__file__).resolve().parents[1] / "radarViewer.py"
+    spec = importlib.util.spec_from_file_location("radar_viewer", script_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class MatplotlibCompatibilityTest(unittest.TestCase):
+    def test_cluster_colormap_can_be_created(self):
+        """Matplotlib 3.11 中仍应能初始化聚类器。"""
+        radar_viewer = load_radar_viewer()
+        tk._default_root = tk.Tcl()
+
+        cluster = radar_viewer.RadarCluster()
+
+        self.assertEqual(cluster.cluster_colors.N, 20)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 问题

Matplotlib 3.11 移除了 `plt.cm.get_cmap`，Python 可视化工具会在 `RadarCluster` 初始化阶段抛出 `AttributeError`。

## 根因

脚本通过已移除的 `matplotlib.cm` 接口创建 `tab10` 配色表。

## 修改

- 改用仍受支持的 `plt.get_cmap('tab10', 20)`。
- 新增无 GUI 定向测试，验证 Matplotlib 3.11 初始化路径和 20 色映射。

## 本地验证

- Matplotlib 3.11.1 环境：`test_matplotlib_compatibility.py`，1 项通过。
- 生产脚本与测试文件 AST 解析通过。
- `git -c core.whitespace=cr-at-eol diff --check` 通过。
- PR 范围门禁通过：1 个提交、2 个文件、42 行变更。

## 未运行

未运行真实 Tk 窗口和板卡采集；测试使用轻量 Tk 后端替身覆盖本次启动回归路径。

Fixes #29