### PR TITLE
fix: reject invalid radar object identifiers

### DIFF
--- a/Python雷达可视化工具示例/radarViewer.py
+++ b/Python雷达可视化工具示例/radarViewer.py
@@ -114,11 +114,16 @@ class RadarParser:
             df['FrameNb'] = fnb
             df['Timestamp'] = info['ts']
 
-        numeric_cols = ['ObjId', 'range', 'speed', 'angle', 'RCS', 'snr', 'X', 'Y']
+        # ObjId 是目标行的身份标识：先保留转换失败的 NaN 并丢弃该行，
+        # 避免和其他可选数值字段一样填成 0，伪造出 ObjId=0 的目标。
+        if 'ObjId' in df.columns:
+            df['ObjId'] = pd.to_numeric(df['ObjId'], errors='coerce')
+            df = df.dropna(subset=['ObjId']).reset_index(drop=True)
+
+        numeric_cols = ['range', 'speed', 'angle', 'RCS', 'snr', 'X', 'Y']
         for col in numeric_cols:
             if col in df.columns:
                 df[col] = pd.to_numeric(df[col], errors='coerce').fillna(0)
-        df = df.dropna(subset=['ObjId']).reset_index(drop=True)
         df = df[df['range'] >= 0].reset_index(drop=True)
 
         if 'angle' in df.columns and 'range' in df.columns:

--- a/Python雷达可视化工具示例/tests/test_invalid_objid.py
+++ b/Python雷达可视化工具示例/tests/test_invalid_objid.py
@@ -1,0 +1,54 @@
+import importlib.util
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+
+
+def load_radar_viewer():
+    """在无图形界面的测试环境中加载解析器模块。"""
+    module_path = Path(__file__).resolve().parents[1] / "radarViewer.py"
+    fake_backend = types.ModuleType("matplotlib.backends.backend_tkagg")
+    fake_backend.FigureCanvasTkAgg = object
+
+    module_name = "radar_viewer_invalid_objid_test"
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    original_backend = sys.modules.get("matplotlib.backends.backend_tkagg")
+    sys.modules["matplotlib.backends.backend_tkagg"] = fake_backend
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        if original_backend is None:
+            sys.modules.pop("matplotlib.backends.backend_tkagg", None)
+        else:
+            sys.modules["matplotlib.backends.backend_tkagg"] = original_backend
+    return module
+
+
+radar_viewer = load_radar_viewer()
+
+
+class InvalidObjIdFallbackTest(unittest.TestCase):
+    def test_non_numeric_objid_is_dropped_before_other_numeric_defaults(self):
+        # 无 START/END 元数据的普通 CSV 会走 pandas fallback 路径。
+        csv_text = "\n".join([
+            "ObjId,range,speed,angle,RCS,snr,X,Y,FrameNb,Timestamp",
+            "not-an-id,4.0,1.0,0,2,10,4,0,12,2026-08-11 10:00:00",
+            ",5.0,2.0,0,3,11,5,0,12,2026-08-11 10:00:00",
+            "7,6.0,invalid-speed,0,4,12,6,0,12,2026-08-11 10:00:00",
+        ])
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            fixture = Path(temp_dir) / "targets.csv"
+            fixture.write_text(csv_text, encoding="utf-8")
+            frame = radar_viewer.RadarParser(fixture).get_frame(12)
+
+        self.assertEqual(frame["ObjId"].tolist(), [7.0])
+        # 其他非关键数值字段仍按原有行为填充为 0。
+        self.assertEqual(frame["speed"].tolist(), [0.0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 问题

普通 CSV 中空值或文本 `ObjId` 会被静默转换为合法目标 0，造成身份混淆。

## 根因

`ObjId` 在 `dropna` 前与其他数值字段一起执行了 `fillna(0)`，使后续清理失效。

## 修改

- 单独将 `ObjId` 转为数值并先丢弃无效身份行。
- 保留其他普通数值字段填 0 的既有兼容行为。
- 新增 pandas fallback 回归测试，覆盖文本、空值和合法身份。

## 本地验证

- `test_invalid_objid.py`：1 项通过。
- 生产脚本与测试文件 AST 解析通过。
- `git -c core.whitespace=cr-at-eol diff --check` 通过。
- PR 范围门禁通过：1 个提交、2 个文件、63 行变更。

## 未运行

未运行 GUI 和真实雷达数据流；定向测试覆盖本次 CSV 解析路径。

Fixes #30