### PR TITLE
fix: keep DBSCAN noise centers scalar

### DIFF
--- a/Python雷达可视化工具示例/radarViewer.py
+++ b/Python雷达可视化工具示例/radarViewer.py
@@ -314,9 +314,15 @@ class RadarCluster:
 
         # 给数据添加聚类信息
         df['cluster_id'] = labels
-        df['cluster_center_x'] = df['cluster_id'].map(lambda x: cluster_info.get(x, {}).get('center_x', df['X']))
-        df['cluster_center_y'] = df['cluster_id'].map(lambda x: cluster_info.get(x, {}).get('center_y', df['Y']))
-        df['cluster_size'] = df['cluster_id'].map(lambda x: cluster_info.get(x, {}).get('size', 1))
+        # 噪点没有聚类中心，回退到该点自身坐标，确保每行都是标量。
+        df['cluster_center_x'] = df['X']
+        df['cluster_center_y'] = df['Y']
+        df['cluster_size'] = 1
+        for label, info in cluster_info.items():
+            cluster_mask = df['cluster_id'] == label
+            df.loc[cluster_mask, 'cluster_center_x'] = info['center_x']
+            df.loc[cluster_mask, 'cluster_center_y'] = info['center_y']
+            df.loc[cluster_mask, 'cluster_size'] = info['size']
 
         return df
 

--- a/Python雷达可视化工具示例/tests/test_cluster_noise_center.py
+++ b/Python雷达可视化工具示例/tests/test_cluster_noise_center.py
@@ -1,0 +1,59 @@
+import sys
+import types
+import unittest
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+
+EXAMPLE_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(EXAMPLE_DIR))
+fake_backend = types.ModuleType('matplotlib.backends.backend_tkagg')
+fake_backend.FigureCanvasTkAgg = object
+sys.modules['matplotlib.backends.backend_tkagg'] = fake_backend
+
+import radarViewer  # noqa: E402
+
+
+class _Value:
+    """为聚类单测提供不依赖图形界面的 Tk 变量替身。"""
+
+    def __init__(self, value):
+        self.value = value
+
+    def get(self):
+        return self.value
+
+
+class RadarClusterNoiseCenterTest(unittest.TestCase):
+    def test_noise_center_falls_back_to_its_own_scalar_coordinates(self):
+        cluster = radarViewer.RadarCluster.__new__(radarViewer.RadarCluster)
+        cluster.enable_clustering = _Value(True)
+        cluster.eps = _Value(0.5)
+        cluster.min_samples = _Value(2)
+
+        points = pd.DataFrame({
+            'X': [0.0, 0.2, 10.0],
+            'Y': [0.0, 0.2, 20.0],
+        })
+
+        result = cluster.cluster(points)
+
+        grouped = result[result['cluster_id'] == 0]
+        for center in grouped['cluster_center_x']:
+            self.assertAlmostEqual(center, 0.1)
+        for center in grouped['cluster_center_y']:
+            self.assertAlmostEqual(center, 0.1)
+        self.assertEqual(grouped['cluster_size'].tolist(), [2, 2])
+
+        noise = result[result['cluster_id'] == -1].iloc[0]
+        self.assertEqual(noise['cluster_center_x'], 10.0)
+        self.assertEqual(noise['cluster_center_y'], 20.0)
+        self.assertEqual(noise['cluster_size'], 1)
+        self.assertTrue(all(np.isscalar(value) for value in result['cluster_center_x']))
+        self.assertTrue(all(np.isscalar(value) for value in result['cluster_center_y']))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## 问题

DBSCAN 噪点的 `cluster_center_x/y` 单元格会保存整列 Pandas Series，而不是数值标量。

## 根因

标签 `-1` 没有中心映射时，逐行 fallback 返回了 `df['X']` / `df['Y']` 整列。

## 修改

- 先将每行自身 X/Y 作为中心默认值。
- 仅用掩码覆盖真实聚类的中心和大小。
- 新增正常聚类与噪点混合回归测试。

## 本地验证

- `test_cluster_noise_center.py`：1 项通过，验证噪点中心均为标量。
- 生产脚本与测试文件 AST 解析通过。
- `git -c core.whitespace=cr-at-eol diff --check` 通过。
- PR 范围门禁通过：1 个提交、2 个文件、71 行变更。

## 未运行

未运行真实 GUI 绘图；定向测试直接验证聚类结果数据结构。

Fixes #31