### PR TITLE
fix: degrade tracking without SciPy

### DIFF
--- a/Python雷达可视化工具示例/radarViewer.py
+++ b/Python雷达可视化工具示例/radarViewer.py
@@ -12,10 +12,12 @@ from collections import deque, defaultdict
 # 第三方库依赖处理
 try:
     from sklearn.cluster import DBSCAN
+except ImportError:
+    DBSCAN = None
+
+try:
     from scipy.optimize import linear_sum_assignment
 except ImportError:
-    messagebox.showwarning("依赖缺失", "请安装依赖：pip install scikit-learn scipy")
-    DBSCAN = None
     linear_sum_assignment = None
 
 plt.rcParams['font.sans-serif'] = ['SimHei']
@@ -171,7 +173,7 @@ class RadarFilter:
 # ---------------------- 3. 卡尔曼目标跟踪器 ----------------------
 class KalmanTracker:
     def __init__(self):
-        self.enable_tracking = BooleanVar(value=True)
+        self.enable_tracking = BooleanVar(value=linear_sum_assignment is not None)
         self.match_thresh = DoubleVar(value=5.0)  # 匹配距离阈值
         self.max_lost_frames = IntVar(value=3)    # 最大丢失帧数
         self.next_id = 0
@@ -208,7 +210,7 @@ class KalmanTracker:
         return track
 
     def track(self, df):
-        if not self.enable_tracking.get() or df.empty:
+        if not self.enable_tracking.get() or df.empty or linear_sum_assignment is None:
             df['track_id'] = df['ObjId'] if 'ObjId' in df.columns else range(len(df))
             return df
         
@@ -600,6 +602,10 @@ class RadarPlayer(tk.Tk):
         self.update_frame()
 
     def _setup_track_tab(self, parent):
+        if linear_sum_assignment is None:
+            ttk.Label(parent, text="请安装依赖：pip install scipy", foreground="red").pack(pady=10)
+            return
+
         ttk.Checkbutton(parent, text="启用卡尔曼跟踪", variable=self.tracker.enable_tracking).pack(anchor=tk.W, pady=(0, 8))
         
         param_frame = ttk.LabelFrame(parent, text="跟踪参数", padding=8)

--- a/Python雷达可视化工具示例/tests/test_tracking_without_scipy.py
+++ b/Python雷达可视化工具示例/tests/test_tracking_without_scipy.py
@@ -1,0 +1,48 @@
+"""验证缺少 SciPy 时跟踪功能能够安全降级。"""
+
+import importlib.util
+import os
+from pathlib import Path
+import sys
+import tkinter as tk
+import types
+import unittest
+
+import pandas as pd
+
+
+os.environ.setdefault("MPLBACKEND", "Agg")
+
+
+def load_radar_viewer():
+    """在无图形窗口的测试环境中加载示例脚本。"""
+    fake_backend = types.ModuleType("matplotlib.backends.backend_tkagg")
+    fake_backend.FigureCanvasTkAgg = object
+    sys.modules["matplotlib.backends.backend_tkagg"] = fake_backend
+
+    script_path = Path(__file__).resolve().parents[1] / "radarViewer.py"
+    spec = importlib.util.spec_from_file_location("radar_viewer", script_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class TrackingWithoutScipyTest(unittest.TestCase):
+    def test_tracking_falls_back_to_object_ids(self):
+        radar_viewer = load_radar_viewer()
+        tk._default_root = tk.Tcl()
+        tracker = radar_viewer.KalmanTracker()
+        tracker.enable_tracking.set(True)
+        radar_viewer.linear_sum_assignment = None
+        frame = pd.DataFrame({"ObjId": [7], "X": [1.0], "Y": [2.0]})
+
+        first = tracker.track(frame.copy())
+        second = tracker.track(frame.copy())
+
+        self.assertEqual(first["track_id"].tolist(), [7])
+        self.assertEqual(second["track_id"].tolist(), [7])
+        self.assertEqual(tracker.tracked_targets, {})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 问题

缺少 SciPy 时目标跟踪仍默认启用，第二个非空帧会调用 `None` 并崩溃。

## 根因

scikit-learn 与 SciPy 共用导入异常处理，同时界面和跟踪器没有为 `linear_sum_assignment` 缺失提供降级路径。

## 修改

- 分离 DBSCAN 与线性分配依赖的导入状态。
- 缺少 SciPy 时默认关闭完整跟踪，并以 `ObjId` 保持可显示身份。
- 跟踪页显示明确的 SciPy 安装提示。
- 新增连续两帧的无 SciPy 回归测试。

## 本地验证

- `test_tracking_without_scipy.py`：1 项通过。
- 生产脚本与测试文件 AST 解析通过。
- `git -c core.whitespace=cr-at-eol diff --check` 通过。
- PR 范围门禁通过：1 个提交、2 个文件、62 行变更。

## 未运行

未运行完整 Tk GUI；测试覆盖依赖缺失和连续帧降级路径。

Fixes #32