### PR TITLE
fix: parse rectangular radar CSV files

### DIFF
--- a/Python雷达可视化工具示例/radarViewer.py
+++ b/Python雷达可视化工具示例/radarViewer.py
@@ -39,7 +39,8 @@ class RadarParser:
                 self.header_line = line.split(',')
                 break
         if self.header_line is None:
-            raise ValueError("未找到有效数据表头，文件格式不支持")
+            self._load_tabular_file()
+            return
 
         current_frame = None
         current_timestamp = None
@@ -78,17 +79,27 @@ class RadarParser:
                     }
 
         if not self.frame_index:
-            df = pd.read_csv(self.file_path, on_bad_lines='skip')
-            if 'FrameNb' not in df.columns:
-                df['FrameNb'] = 0
-            if 'Timestamp' not in df.columns:
-                df['Timestamp'] = datetime.now()
-            for fnb in df['FrameNb'].unique():
-                self.frame_index[fnb] = {
-                    'ts': df[df['FrameNb']==fnb]['Timestamp'].iloc[0],
-                    'count': len(df[df['FrameNb']==fnb])
-                }
-            self.df_all = df
+            self._load_tabular_file()
+
+    def _load_tabular_file(self):
+        """加载没有 START/END 元数据行的普通矩形 CSV。"""
+        df = pd.read_csv(self.file_path, on_bad_lines='skip')
+        required_columns = {'ObjId', 'range'}
+        missing_columns = required_columns.difference(df.columns)
+        if missing_columns:
+            missing = ', '.join(sorted(missing_columns))
+            raise ValueError(f"缺少必要数据列：{missing}")
+        if 'FrameNb' not in df.columns:
+            df['FrameNb'] = 0
+        if 'Timestamp' not in df.columns:
+            df['Timestamp'] = datetime.now()
+        for fnb in df['FrameNb'].unique():
+            frame = df[df['FrameNb'] == fnb]
+            self.frame_index[fnb] = {
+                'ts': frame['Timestamp'].iloc[0],
+                'count': len(frame)
+            }
+        self.df_all = df
 
     def get_frame(self, fnb):
         if fnb not in self.frame_index:

--- a/Python雷达可视化工具示例/tests/test_tabular_csv_fallback.py
+++ b/Python雷达可视化工具示例/tests/test_tabular_csv_fallback.py
@@ -1,0 +1,48 @@
+"""验证普通矩形 CSV 能进入备用解析路径。"""
+
+import importlib.util
+import os
+from pathlib import Path
+import sys
+import tempfile
+import types
+import unittest
+
+
+os.environ.setdefault("MPLBACKEND", "Agg")
+
+
+def load_radar_viewer():
+    """在无图形窗口的测试环境中加载示例脚本。"""
+    fake_backend = types.ModuleType("matplotlib.backends.backend_tkagg")
+    fake_backend.FigureCanvasTkAgg = object
+    sys.modules["matplotlib.backends.backend_tkagg"] = fake_backend
+
+    script_path = Path(__file__).resolve().parents[1] / "radarViewer.py"
+    spec = importlib.util.spec_from_file_location("radar_viewer", script_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class TabularCsvFallbackTest(unittest.TestCase):
+    def test_frame_number_can_precede_object_id(self):
+        radar_viewer = load_radar_viewer()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            fixture = Path(temp_dir) / "targets.csv"
+            fixture.write_text(
+                "FrameNb,ObjId,range,speed,angle,RCS,snr,X,Y\n"
+                "12,7,2.5,0.1,-5,3,20,2.49,-0.22\n",
+                encoding="utf-8",
+            )
+
+            parser = radar_viewer.RadarParser(fixture)
+            frame = parser.get_frame(12)
+
+        self.assertEqual(list(parser.frame_index), [12])
+        self.assertEqual(frame["ObjId"].tolist(), [7])
+        self.assertEqual(frame["range"].tolist(), [2.5])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 问题

表头以 `FrameNb` 开头的普通矩形 CSV 会在既有 pandas fallback 执行前被拒绝。

## 根因

文件扫描阶段先强制首行以 `ObjId,` 开头，导致无 START/END 标记的合法表格无法进入备用解析。

## 修改

- 将普通表格加载与必需列验证提取为独立路径。
- 无结构化帧标记时按 `FrameNb` 分帧。
- 缺少必需列时保留清晰格式错误。
- 新增 `FrameNb,ObjId,...` 回归测试。

## 本地验证

- `test_tabular_csv_fallback.py`：1 项通过。
- 生产脚本与测试文件 AST 解析通过。
- `git -c core.whitespace=cr-at-eol diff --check` 通过。
- PR 范围门禁通过：1 个提交、2 个文件、83 行变更。

## 未运行

未运行 GUI 文件选择器；定向测试覆盖普通 CSV 初始化与取帧路径。

Fixes #33