### PR TITLE
docs: include Python tracking dependencies

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -238,8 +238,10 @@ USB-CAN FD 端子可能还包含其他引脚，不要把中间端子直接当作
 请执行：
 
 ```bash
-python -m pip install pandas matplotlib numpy
+python -m pip install numpy pandas matplotlib scipy scikit-learn
 ```
+
+脚本使用 SciPy 和 scikit-learn 实现目标跟踪与 DBSCAN 聚类。请完整安装上述依赖，否则相关功能无法正常使用。
 
 若仍然报错，请确认当前终端使用的 Python 环境与安装依赖的 Python 环境一致。
 

--- a/docs/Python 可视化/环境要求.md
+++ b/docs/Python 可视化/环境要求.md
@@ -21,8 +21,10 @@ Python 3.8+
 安装依赖库：
 
 ```bash
-python -m pip install pandas matplotlib numpy
+python -m pip install numpy pandas matplotlib scipy scikit-learn
 ```
+
+脚本使用 SciPy 和 scikit-learn 实现目标跟踪与 DBSCAN 聚类。请完整安装上述依赖，否则相关功能无法正常使用。
 
 ### 示例工程目录
 


### PR DESCRIPTION
## 问题

Python 环境文档和 FAQ 的安装命令遗漏 SciPy 与 scikit-learn，而脚本的目标跟踪和 DBSCAN 聚类实际依赖它们。

## 修改

- 两处命令统一为 `python -m pip install numpy pandas matplotlib scipy scikit-learn`。
- 说明 SciPy 用于目标跟踪，scikit-learn 用于 DBSCAN 聚类。

## 本地验证

- 对照脚本导入与两处文档依赖名称，结果一致。
- `git diff --check` 通过。
- markdownlint 告警数量与基线相同，本 PR 未新增告警类别或数量。
- PR 范围门禁通过：1 个提交、2 个文件、8 行变更。

## 未运行

纯文档修复，未安装依赖或运行 GUI；未改变本机 Python 环境。

Fixes #35