### PR TITLE
docs: correct Octave project metadata

### DIFF
--- a/community/projects/a100-indoor-cart-mti/project.yaml
+++ b/community/projects/a100-indoor-cart-mti/project.yaml
@@ -13,8 +13,12 @@ data_types:
   - "TraTarget track CSV"
   - "CAN ASC"
 development_environment:
-  - "MATLAB"
+  - "GNU Octave 11.3.0"
   - "Windows"
+runtime_dependencies:
+  - "Octave signal 1.4.7"
+compatibility:
+  - "MATLAB-compatible .m files"
 algorithms:
   - "LFMCW simulation"
   - "Range FFT"


### PR DESCRIPTION
## 问题

室内推车 MTI 社区项目的 YAML 只声明 MATLAB，未记录 README 和环境脚本实际验证的 GNU Octave 11.3.0 与 signal 1.4.7。

## 修改

- 开发环境记录 GNU Octave 11.3.0 和 Windows。
- 运行时依赖记录 Octave signal 1.4.7。
- 单独保留 MATLAB-compatible `.m` 兼容性说明。

## 本地验证

- Ruby `YAML.safe_load` 成功解析修改后的元数据并验证目标字段。
- 与项目 README、索引和 `prepare_environment.m` 的版本说明交叉核对一致。
- `git diff --check` 通过。
- PR 范围门禁通过：1 个提交、1 个文件、6 行变更。

## 未运行

本机未安装 Octave；本 PR 只修正机器可读元数据，不修改或执行算法。

Fixes #37