### PR TITLE
fix: stabilize Python visualization and CSV parsing

### DIFF
--- a/Python雷达可视化工具示例/radarViewer.py
+++ b/Python雷达可视化工具示例/radarViewer.py
@@ -12,10 +12,12 @@ from collections import deque, defaultdict
 # 第三方库依赖处理
 try:
     from sklearn.cluster import DBSCAN
+except ImportError:
+    DBSCAN = None
+
+try:
     from scipy.optimize import linear_sum_assignment
 except ImportError:
-    messagebox.showwarning("依赖缺失", "请安装依赖：pip install scikit-learn scipy")
-    DBSCAN = None
     linear_sum_assignment = None
 
 plt.rcParams['font.sans-serif'] = ['SimHei']
@@ -39,7 +41,8 @@ class RadarParser:
                 self.header_line = line.split(',')
                 break
         if self.header_line is None:
-            raise ValueError("未找到有效数据表头，文件格式不支持")
+            self._load_tabular_file()
+            return
 
         current_frame = None
         current_timestamp = None
@@ -78,17 +81,27 @@ class RadarParser:
                     }
 
         if not self.frame_index:
-            df = pd.read_csv(self.file_path, on_bad_lines='skip')
-            if 'FrameNb' not in df.columns:
-                df['FrameNb'] = 0
-            if 'Timestamp' not in df.columns:
-                df['Timestamp'] = datetime.now()
-            for fnb in df['FrameNb'].unique():
-                self.frame_index[fnb] = {
-                    'ts': df[df['FrameNb']==fnb]['Timestamp'].iloc[0],
-                    'count': len(df[df['FrameNb']==fnb])
-                }
-            self.df_all = df
+            self._load_tabular_file()
+
+    def _load_tabular_file(self):
+        """加载没有 START/END 元数据行的普通矩形 CSV。"""
+        df = pd.read_csv(self.file_path, on_bad_lines='skip')
+        required_columns = {'ObjId', 'range'}
+        missing_columns = required_columns.difference(df.columns)
+        if missing_columns:
+            missing = ', '.join(sorted(missing_columns))
+            raise ValueError(f"缺少必要数据列：{missing}")
+        if 'FrameNb' not in df.columns:
+            df['FrameNb'] = 0
+        if 'Timestamp' not in df.columns:
+            df['Timestamp'] = datetime.now()
+        for fnb in df['FrameNb'].unique():
+            frame = df[df['FrameNb'] == fnb]
+            self.frame_index[fnb] = {
+                'ts': frame['Timestamp'].iloc[0],
+                'count': len(frame)
+            }
+        self.df_all = df
 
     def get_frame(self, fnb):
         if fnb not in self.frame_index:
@@ -114,11 +127,15 @@ class RadarParser:
             df['FrameNb'] = fnb
             df['Timestamp'] = info['ts']
 
-        numeric_cols = ['ObjId', 'range', 'speed', 'angle', 'RCS', 'snr', 'X', 'Y']
+        # 身份转换失败的行必须先移除，不能和普通数值缺失值一样填成 0。
+        if 'ObjId' in df.columns:
+            df['ObjId'] = pd.to_numeric(df['ObjId'], errors='coerce')
+            df = df.dropna(subset=['ObjId']).reset_index(drop=True)
+
+        numeric_cols = ['range', 'speed', 'angle', 'RCS', 'snr', 'X', 'Y']
         for col in numeric_cols:
             if col in df.columns:
                 df[col] = pd.to_numeric(df[col], errors='coerce').fillna(0)
-        df = df.dropna(subset=['ObjId']).reset_index(drop=True)
         df = df[df['range'] >= 0].reset_index(drop=True)
 
         if 'angle' in df.columns and 'range' in df.columns:
@@ -171,7 +188,7 @@ class RadarFilter:
 # ---------------------- 3. 卡尔曼目标跟踪器 ----------------------
 class KalmanTracker:
     def __init__(self):
-        self.enable_tracking = BooleanVar(value=True)
+        self.enable_tracking = BooleanVar(value=linear_sum_assignment is not None)
         self.match_thresh = DoubleVar(value=5.0)  # 匹配距离阈值
         self.max_lost_frames = IntVar(value=3)    # 最大丢失帧数
         self.next_id = 0
@@ -208,7 +225,7 @@ class KalmanTracker:
         return track
 
     def track(self, df):
-        if not self.enable_tracking.get() or df.empty:
+        if not self.enable_tracking.get() or df.empty or linear_sum_assignment is None:
             df['track_id'] = df['ObjId'] if 'ObjId' in df.columns else range(len(df))
             return df
         
@@ -282,7 +299,7 @@ class RadarCluster:
         self.enable_clustering = BooleanVar(value=False)
         self.eps = DoubleVar(value=2.0)  # 聚类半径
         self.min_samples = IntVar(value=2)  # 最小样本数
-        self.cluster_colors = plt.cm.get_cmap('tab10', 20)  # 聚类颜色映射
+        self.cluster_colors = plt.get_cmap('tab10', 20)  # 聚类颜色映射
 
     def cluster(self, df):
         if not self.enable_clustering.get() or df.empty or DBSCAN is None:
@@ -314,9 +331,15 @@ class RadarCluster:
 
         # 给数据添加聚类信息
         df['cluster_id'] = labels
-        df['cluster_center_x'] = df['cluster_id'].map(lambda x: cluster_info.get(x, {}).get('center_x', df['X']))
-        df['cluster_center_y'] = df['cluster_id'].map(lambda x: cluster_info.get(x, {}).get('center_y', df['Y']))
-        df['cluster_size'] = df['cluster_id'].map(lambda x: cluster_info.get(x, {}).get('size', 1))
+        # 噪点没有聚类中心，回退到该行自身坐标，确保每个单元格都是标量。
+        df['cluster_center_x'] = df['X']
+        df['cluster_center_y'] = df['Y']
+        df['cluster_size'] = 1
+        for label, info in cluster_info.items():
+            cluster_mask = df['cluster_id'] == label
+            df.loc[cluster_mask, 'cluster_center_x'] = info['center_x']
+            df.loc[cluster_mask, 'cluster_center_y'] = info['center_y']
+            df.loc[cluster_mask, 'cluster_size'] = info['size']
 
         return df
 
@@ -600,6 +623,10 @@ class RadarPlayer(tk.Tk):
         self.update_frame()
 
     def _setup_track_tab(self, parent):
+        if linear_sum_assignment is None:
+            ttk.Label(parent, text="请安装依赖：pip install scipy", foreground="red").pack(pady=10)
+            return
+
         ttk.Checkbutton(parent, text="启用卡尔曼跟踪", variable=self.tracker.enable_tracking).pack(anchor=tk.W, pady=(0, 8))
         
         param_frame = ttk.LabelFrame(parent, text="跟踪参数", padding=8)
@@ -807,13 +834,19 @@ class RadarPlayer(tk.Tk):
     def toggle(self):
         if not self.fns:
             return
-        self.playing = not self.playing
         if self.playing:
-            self.loop()
+            self.playing = False
+            if self.timer is not None:
+                self.after_cancel(self.timer)
+                self.timer = None
+            return
+        self.playing = True
+        self.loop()
 
     def loop(self):
         if not self.playing or not self.fns:
             return
+        self.timer = None
         idx = self.fns.index(self.current)
         if idx + 1 >= len(self.fns):
             self.playing = False

--- a/Python雷达可视化工具示例/tests/_support.py
+++ b/Python雷达可视化工具示例/tests/_support.py
@@ -1,0 +1,59 @@
+"""Python 雷达可视化工具测试的无图形界面加载辅助函数。"""
+
+from contextlib import contextmanager
+import importlib.util
+import os
+from pathlib import Path
+import sys
+import tkinter as tk
+import types
+
+
+os.environ.setdefault("MPLBACKEND", "Agg")
+EXAMPLE_DIR = Path(__file__).resolve().parents[1]
+_MISSING = object()
+
+
+def load_radar_viewer(module_name, *, without_scipy=False):
+    """隔离加载示例脚本，并恢复临时替换的后端与可选依赖。"""
+    fake_backend = types.ModuleType("matplotlib.backends.backend_tkagg")
+    fake_backend.FigureCanvasTkAgg = object
+    replacements = {"matplotlib.backends.backend_tkagg": fake_backend}
+    if without_scipy:
+        replacements["scipy.optimize"] = types.ModuleType("scipy.optimize")
+
+    originals = {name: sys.modules.get(name, _MISSING) for name in replacements}
+    sys.modules.update(replacements)
+    try:
+        script_path = EXAMPLE_DIR / "radarViewer.py"
+        spec = importlib.util.spec_from_file_location(module_name, script_path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        for name, original in originals.items():
+            if original is _MISSING:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = original
+
+
+@contextmanager
+def tkinter_root():
+    """为 Tk 变量提供临时 Tcl 根，并在测试后恢复全局状态。"""
+    original_root = tk._default_root
+    tk._default_root = tk.Tcl()
+    try:
+        yield
+    finally:
+        tk._default_root = original_root
+
+
+class Value:
+    """提供测试所需的最小 Tk 变量接口。"""
+
+    def __init__(self, value):
+        self.value = value
+
+    def get(self):
+        return self.value

--- a/Python雷达可视化工具示例/tests/test_cluster_noise_center.py
+++ b/Python雷达可视化工具示例/tests/test_cluster_noise_center.py
@@ -1,0 +1,33 @@
+"""验证 DBSCAN 噪点中心保持数值标量。"""
+
+import unittest
+
+import numpy as np
+import pandas as pd
+
+from _support import load_radar_viewer, Value
+
+
+class RadarClusterNoiseCenterTest(unittest.TestCase):
+    def test_noise_center_uses_its_own_coordinates(self):
+        radar_viewer = load_radar_viewer("radar_viewer_cluster_test")
+        cluster = radar_viewer.RadarCluster.__new__(radar_viewer.RadarCluster)
+        cluster.enable_clustering = Value(True)
+        cluster.eps = Value(0.5)
+        cluster.min_samples = Value(2)
+        points = pd.DataFrame({"X": [0.0, 0.2, 10.0], "Y": [0.0, 0.2, 20.0]})
+
+        result = cluster.cluster(points)
+
+        grouped = result[result["cluster_id"] == 0]
+        self.assertEqual(grouped["cluster_size"].tolist(), [2, 2])
+        self.assertTrue(all(np.isclose(grouped["cluster_center_x"], 0.1)))
+        self.assertTrue(all(np.isclose(grouped["cluster_center_y"], 0.1)))
+        noise = result[result["cluster_id"] == -1].iloc[0]
+        self.assertEqual((noise["cluster_center_x"], noise["cluster_center_y"]), (10.0, 20.0))
+        self.assertTrue(all(np.isscalar(value) for value in result["cluster_center_x"]))
+        self.assertTrue(all(np.isscalar(value) for value in result["cluster_center_y"]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Python雷达可视化工具示例/tests/test_invalid_objid.py
+++ b/Python雷达可视化工具示例/tests/test_invalid_objid.py
@@ -1,0 +1,30 @@
+"""验证无效目标标识不会被伪装成目标 0。"""
+
+from pathlib import Path
+import tempfile
+import unittest
+
+from _support import load_radar_viewer
+
+
+class InvalidObjIdFallbackTest(unittest.TestCase):
+    def test_invalid_objid_is_dropped_before_numeric_defaults(self):
+        radar_viewer = load_radar_viewer("radar_viewer_invalid_objid_test")
+        csv_text = "\n".join([
+            "ObjId,range,speed,angle,RCS,snr,X,Y,FrameNb,Timestamp",
+            "not-an-id,4.0,1.0,0,2,10,4,0,12,2026-08-11 10:00:00",
+            ",5.0,2.0,0,3,11,5,0,12,2026-08-11 10:00:00",
+            "7,6.0,invalid-speed,0,4,12,6,0,12,2026-08-11 10:00:00",
+        ])
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            fixture = Path(temp_dir) / "targets.csv"
+            fixture.write_text(csv_text, encoding="utf-8")
+            frame = radar_viewer.RadarParser(fixture).get_frame(12)
+
+        self.assertEqual(frame["ObjId"].tolist(), [7.0])
+        self.assertEqual(frame["speed"].tolist(), [0.0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Python雷达可视化工具示例/tests/test_matplotlib_compatibility.py
+++ b/Python雷达可视化工具示例/tests/test_matplotlib_compatibility.py
@@ -1,0 +1,19 @@
+"""验证当前 Matplotlib 配色 API 的兼容性。"""
+
+import unittest
+
+from _support import load_radar_viewer, tkinter_root
+
+
+class MatplotlibCompatibilityTest(unittest.TestCase):
+    def test_cluster_colormap_can_be_created(self):
+        radar_viewer = load_radar_viewer("radar_viewer_matplotlib_test")
+
+        with tkinter_root():
+            cluster = radar_viewer.RadarCluster()
+
+        self.assertEqual(cluster.cluster_colors.N, 20)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Python雷达可视化工具示例/tests/test_playback_timer.py
+++ b/Python雷达可视化工具示例/tests/test_playback_timer.py
@@ -1,0 +1,48 @@
+"""验证暂停播放会取消待执行的回调。"""
+
+import types
+import unittest
+
+from _support import load_radar_viewer
+
+
+class PlaybackTimerTest(unittest.TestCase):
+    def test_pause_cancels_pending_callback_before_resume(self):
+        radar_viewer = load_radar_viewer("radar_viewer_timer_test")
+
+        class FakePlayer:
+            toggle = radar_viewer.RadarPlayer.toggle
+            loop = radar_viewer.RadarPlayer.loop
+
+            def __init__(self):
+                self.fns = [0, 1, 2]
+                self.current = 0
+                self.playing = True
+                self.timer = "pending-timer"
+                self.cancelled = []
+                self.scheduled = []
+                self.speed_var = types.SimpleNamespace(get=lambda: 100)
+
+            def update_frame(self):
+                pass
+
+            def after(self, delay, callback):
+                token = f"timer-{len(self.scheduled) + 1}"
+                self.scheduled.append((token, delay, callback))
+                return token
+
+            def after_cancel(self, token):
+                self.cancelled.append(token)
+
+        player = FakePlayer()
+        player.toggle()
+        player.toggle()
+
+        self.assertEqual(player.cancelled, ["pending-timer"])
+        self.assertEqual(len(player.scheduled), 1)
+        self.assertEqual(player.timer, "timer-1")
+        self.assertEqual(player.current, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Python雷达可视化工具示例/tests/test_tabular_csv_fallback.py
+++ b/Python雷达可视化工具示例/tests/test_tabular_csv_fallback.py
@@ -1,0 +1,29 @@
+"""验证普通矩形 CSV 能进入备用解析路径。"""
+
+from pathlib import Path
+import tempfile
+import unittest
+
+from _support import load_radar_viewer
+
+
+class TabularCsvFallbackTest(unittest.TestCase):
+    def test_frame_number_can_precede_object_id(self):
+        radar_viewer = load_radar_viewer("radar_viewer_tabular_test")
+        with tempfile.TemporaryDirectory() as temp_dir:
+            fixture = Path(temp_dir) / "targets.csv"
+            fixture.write_text(
+                "FrameNb,ObjId,range,speed,angle,RCS,snr,X,Y\n"
+                "12,7,2.5,0.1,-5,3,20,2.49,-0.22\n",
+                encoding="utf-8",
+            )
+            parser = radar_viewer.RadarParser(fixture)
+            frame = parser.get_frame(12)
+
+        self.assertEqual(list(parser.frame_index), [12])
+        self.assertEqual(frame["ObjId"].tolist(), [7])
+        self.assertEqual(frame["range"].tolist(), [2.5])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Python雷达可视化工具示例/tests/test_tracking_without_scipy.py
+++ b/Python雷达可视化工具示例/tests/test_tracking_without_scipy.py
@@ -1,0 +1,27 @@
+"""验证缺少 SciPy 时目标跟踪安全降级。"""
+
+import unittest
+
+import pandas as pd
+
+from _support import load_radar_viewer, tkinter_root
+
+
+class TrackingWithoutScipyTest(unittest.TestCase):
+    def test_tracking_falls_back_to_object_ids(self):
+        radar_viewer = load_radar_viewer("radar_viewer_no_scipy_test", without_scipy=True)
+        with tkinter_root():
+            tracker = radar_viewer.KalmanTracker()
+            self.assertFalse(tracker.enable_tracking.get())
+            tracker.enable_tracking.set(True)
+
+        frame = pd.DataFrame({"ObjId": [7], "X": [1.0], "Y": [2.0]})
+        first = tracker.track(frame.copy())
+        second = tracker.track(frame.copy())
+
+        self.assertEqual(first["track_id"].tolist(), [7])
+        self.assertEqual(second["track_id"].tolist(), [7])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 背景

本 PR 按维护者在 #48 的重组建议，将原 #39–#44 合并为一个可集中评审的 Python 可视化稳定性与数据解析修复。

## 根因与修改

- 使用 Matplotlib 3.11 支持的 colormap API。
- 在填充其他数值默认值前丢弃无效 ObjId。
- 确保 DBSCAN 噪点中心为当前行的标量坐标。
- 分离 SciPy 与 scikit-learn 的可选依赖状态；缺少 SciPy 时安全降级跟踪。
- 支持 FrameNb 在首列的普通矩形 CSV，并验证必要列。
- 暂停播放时取消待执行 Tk after 任务，防止恢复后形成重复计时器链。
- 增加统一的无 GUI 测试辅助模块与 6 项回归测试。

## 本地验证

- Python 3.13.3。
- Matplotlib 3.11.1、NumPy 2.5.2、Pandas 3.0.5、SciPy 1.18.1、scikit-learn 1.9.0。
- 定向 unittest：6/6 通过。
- compileall：通过。
- git diff --check：通过。
- 范围门禁：8 个文件，新增 303 行、删除 25 行，共 328/400 行。

## 未运行

未运行真实 Tk 窗口人工交互、真实雷达数据流或板卡采集；无 GUI 回归覆盖了本次六条修复路径。

Fixes #29
Fixes #30
Fixes #31
Fixes #32
Fixes #33
Fixes #34