### PR TITLE
docs: record Octave runtime metadata

### DIFF
--- a/community/projects/a100-indoor-cart-mti/project.yaml
+++ b/community/projects/a100-indoor-cart-mti/project.yaml
@@ -13,8 +13,12 @@ data_types:
   - "TraTarget track CSV"
   - "CAN ASC"
 development_environment:
-  - "MATLAB"
+  - "GNU Octave 11.3.0"
   - "Windows"
+runtime_dependencies:
+  - "Octave signal 1.4.7"
+compatibility:
+  - "MATLAB-compatible .m files"
 algorithms:
   - "LFMCW simulation"
   - "Range FFT"


### PR DESCRIPTION
## 背景

本 PR 按维护者在 #48 的重组建议，单独整理原 #47 的 Community Project 元数据修复。

## 修改

- 在 a100-indoor-cart-mti 的 project.yaml 中记录实际验证的 GNU Octave 11.3.0。
- 记录 Octave signal 1.4.7 运行时依赖。
- 保留 MATLAB-compatible .m 文件兼容性说明。

## 本地验证

- Ruby YAML.safe_load 解析通过。
- 与项目 README、技术文档和环境准备脚本交叉核对一致。
- git diff --check：通过。
- 范围门禁：1 个文件，新增 5 行、删除 1 行，共 6/400 行。

## 未运行

本机未安装 MATLAB 或 Octave；本 PR 只修正机器可读元数据，不改变算法实现。

Fixes #37