### PR TITLE
docs: align ADC capture layouts and examples

### DIFF
--- a/docs/RadarTools/ADC数据分析.md
+++ b/docs/RadarTools/ADC数据分析.md
@@ -66,30 +66,37 @@ RadarTools/RadarTools_Release/adcData/
 ADC数据采集/matlab_signal_processing_platform_231023_for_txt_A100/data/
 ```
 
-若数据包含多个接收通道，请确保所有通道文件均已拷贝完整。
+若数据位于会话子目录中，可以复制整个会话目录，也可以将所需文件直接复制到
+示例工程的 `data/` 目录。多通道分析应选择同一会话、同一波形配置（profile）的
+`Rx0`～`Rx3` 文件。
 
 ### 配置数据路径和文件名
 
 在 `ct_signal_processing_main_simple_CTASIA100.m` 中配置 ADC 数据所在目录：
 
 ```matlab
-cell_data_file_path = {
-    '.\data\'
-};
+cell_data_file_path = '.\data';
 ```
 
-配置接收通道对应的数据文件名：
+配置接收通道对应的数据文件名。以下示例使用仓库现有的旧版平铺文件：
 
 ```matlab
 cell_data_file_name_list = {
-    'adc_rx0.txt'
-    'adc_rx1.txt'
-    'adc_rx2.txt'
-    'adc_rx3.txt'
+    [cell_data_file_path, '\', 'adc_test_20260522110324_Pf0_Rx0.txt'];
+    [cell_data_file_path, '\', 'adc_test_20260522110332_Pf0_Rx1.txt'];
+    [cell_data_file_path, '\', 'adc_test_20260522110341_Pf0_Rx2.txt'];
+    [cell_data_file_path, '\', 'adc_test_20260522110350_Pf0_Rx3.txt'];
 };
 ```
 
-文件名需与 `data/` 目录中的实际文件保持一致。
+如果保留会话子目录，应在文件名中包含该目录。例如：
+
+```matlab
+fullfile(cell_data_file_path, 'adc_test_20260707154459626', ...
+    'run_001_Pf0_Rx0.txt')
+```
+
+文件名、波形配置和接收通道必须与本次采集文件保持一致。
 
 ### 运行 Matlab 处理脚本
 

--- a/docs/RadarTools/ADC数据采集.md
+++ b/docs/RadarTools/ADC数据采集.md
@@ -39,7 +39,7 @@ ADC 采集界面中通常包含以下配置项：
 
 不同波形对应的 ADC 数据需要使用对应配置文件进行后续解析。
 
-###  ADC 数据保存目录
+### ADC 数据保存目录
 
 ADC 数据采集完成后，数据文件默认保存至：
 
@@ -47,16 +47,23 @@ ADC 数据采集完成后，数据文件默认保存至：
 RadarTools/RadarTools_Release/adcData/
 ```
 
-采集完成后，请确认该目录下已生成对应数据文件。
+采集完成后，请确认该目录下已生成对应数据文件。RadarTools 版本不同，
+输出可能采用会话子目录或旧版平铺目录。
 
-示例目录结构：
+当前仓库同时包含以下两种格式：
 
 ```text
 RadarTools/RadarTools_Release/adcData/
-├── adc_rx0.txt
-├── adc_rx1.txt
-├── adc_rx2.txt
-└── adc_rx3.txt
+├── adc_test_20260707154459626/
+│   ├── run_001_Pf0_Rx0.txt
+│   ├── run_001_Pf0_Rx1.txt
+│   ├── run_001_Pf0_Rx2.txt
+│   └── run_001_Pf0_Rx3.txt
+├── adc_test_20260522110324_Pf0_Rx0.txt
+├── adc_test_20260522110332_Pf0_Rx1.txt
+├── adc_test_20260522110341_Pf0_Rx2.txt
+└── adc_test_20260522110350_Pf0_Rx3.txt
 ```
 
-实际文件名以采集工具生成结果为准。
+文件名中的 `Pf0` 表示采集时使用的波形配置（profile），`Rx0`～`Rx3` 表示接收通道。
+后续分析时，应选择同一会话、同一波形配置的文件，并保留实际文件名。


### PR DESCRIPTION
## 背景

本 PR 按维护者在 #48 的重组建议，单独整理原 #48 的 ADC 文档修复。

## 修改

- 同时记录 RadarTools 会话子目录与旧版平铺文件两种真实布局。
- 说明 Pf 表示波形配置，Rx 表示接收通道。
- 使用仓库中真实存在的文件名更新复制、路径和 MATLAB 配置示例。
- 使 cell_data_file_path 的类型与入口脚本保持一致。

## 本地验证

- 核验文档引用的平铺文件与会话目录文件均存在。
- 对照 MATLAB 入口脚本的 cell_data_file_path 与 cell_data_file_name_list。
- git diff --check：通过。
- 范围门禁：2 个文件，新增 32 行、删除 18 行，共 50/400 行。

## 未运行

纯文档变更，未连接板卡或执行 MATLAB/Octave 分析。

Fixes #38