### PR TITLE
fix(community): validate ADC text integrity

### DIFF
--- a/community/projects/a100-indoor-outdoor-radar-analysis/functions/common/read_adc_txt.m
+++ b/community/projects/a100-indoor-outdoor-radar-analysis/functions/common/read_adc_txt.m
@@ -7,22 +7,46 @@ if fid < 0
     error('Cannot open ADC file: %s', filePath);
 end
 cleanupObj = onCleanup(@() fclose(fid)); %#ok<NASGU>
-dataCell = textscan(fid, '%f', 'Delimiter', ',', 'CollectOutput', true);
-values = dataCell{1};
+tokenCell = textscan(fid, '%s', 'Delimiter', ',');
+values = str2double(tokenCell{1});
 if numel(values) < 4
     error('ADC file is too short: %s', filePath);
 end
 
-header.rx_index = round(values(1));
-header.samples_per_chirp = round(values(2));
-header.chirp_count = round(values(3));
+headerValues = values(1:3);
+if any(~isfinite(headerValues)) || any(headerValues ~= fix(headerValues)) || ...
+        any(abs(headerValues) > flintmax)
+    error('read_adc_txt:InvalidHeader', ...
+        'ADC header fields must be finite, exactly represented integers.');
+end
+
+header.rx_index = headerValues(1);
+header.samples_per_chirp = headerValues(2);
+header.chirp_count = headerValues(3);
 header.file = filePath;
-if mod(header.samples_per_chirp, 2) ~= 0
-    error('samples_per_chirp must be even because two int16 samples share one uint32.');
+if header.rx_index < 0 || header.rx_index > 3
+    error('read_adc_txt:InvalidRxIndex', 'rx_index must be an integer from 0 to 3.');
+end
+if header.samples_per_chirp <= 0 || mod(header.samples_per_chirp, 2) ~= 0
+    error('read_adc_txt:InvalidSamplesPerChirp', ...
+        'samples_per_chirp must be a positive even integer.');
+end
+if header.chirp_count <= 0
+    error('read_adc_txt:InvalidChirpCount', 'chirp_count must be a positive integer.');
 end
 
 expectedWords = header.samples_per_chirp / 2 * header.chirp_count;
+if ~isfinite(expectedWords) || expectedWords ~= fix(expectedWords) || expectedWords > flintmax
+    error('read_adc_txt:InvalidDimensions', ...
+        'Header dimensions produce an invalid packed-word count.');
+end
 payload = values(4:end);
+% uint32 转换会截断或饱和非法输入，必须在转换前拒绝数据损坏。
+if any(~isfinite(payload)) || any(payload ~= fix(payload)) || ...
+        any(payload < 0) || any(payload > double(intmax('uint32')))
+    error('read_adc_txt:InvalidPayload', ...
+        'ADC payload values must be finite uint32 integers.');
+end
 if numel(payload) < expectedWords
     if ioOpts.allow_zero_pad
         warning('ADC payload is short in %s; zero padding %d words.', ...
@@ -35,7 +59,11 @@ if numel(payload) < expectedWords
 end
 trailer = payload(expectedWords+1:end);
 if ~isempty(trailer)
-    fprintf('  %s: ignored %d trailing value(s).\n', ...
+    if any(trailer ~= 0)
+        error('read_adc_txt:NonZeroTrailer', ...
+            'ADC trailer contains non-zero data in %s.', filePath);
+    end
+    fprintf('  %s: verified %d zero padding value(s).\n', ...
         char(filePath), numel(trailer));
 end
 packedWords = uint32(payload(1:expectedWords));

--- a/community/projects/a100-indoor-outdoor-radar-analysis/tests/test_read_adc_txt_validation.m
+++ b/community/projects/a100-indoor-outdoor-radar-analysis/tests/test_read_adc_txt_validation.m
@@ -1,0 +1,69 @@
+function test_read_adc_txt_validation()
+%TEST_READ_ADC_TXT_VALIDATION 验证 ADC token、头部与尾部填充的严格校验。
+
+projectRoot = fileparts(fileparts(mfilename('fullpath')));
+addpath(fullfile(projectRoot, 'functions', 'common'));
+fixture = [tempname '.txt'];
+cleanupObj = onCleanup(@() delete_if_exists(fixture)); %#ok<NASGU>
+ioOpts.allow_zero_pad = false;
+
+valid = [0, 4, 2, 1, 2, 3, double(intmax('uint32')), 0, 0];
+write_values(fixture, valid);
+[words, header, trailer] = read_adc_txt(fixture, ioOpts);
+assert(isequal(words(:), uint32(valid(4:7)).'));
+assert(header.rx_index == 0 && header.samples_per_chirp == 4 && header.chirp_count == 2);
+assert(isequal(trailer(:), [0; 0]));
+
+cases = {
+    [Inf, 4, 2, 1, 2, 3, 4], 'read_adc_txt:InvalidHeader';
+    [0.5, 4, 2, 1, 2, 3, 4], 'read_adc_txt:InvalidHeader';
+    [4, 4, 2, 1, 2, 3, 4], 'read_adc_txt:InvalidRxIndex';
+    [0, 3, 2, 1, 2, 3, 4], 'read_adc_txt:InvalidSamplesPerChirp';
+    [0, 4, 0, 1], 'read_adc_txt:InvalidChirpCount';
+    [0, 4294967294, 4294967295, 1], 'read_adc_txt:InvalidDimensions';
+    [0, 4, 2, 1, 2, NaN, 4], 'read_adc_txt:InvalidPayload';
+    [0, 4, 2, 1, 2, 3.5, 4], 'read_adc_txt:InvalidPayload';
+    [0, 4, 2, 1, 2, -1, 4], 'read_adc_txt:InvalidPayload';
+    [0, 4, 2, 1, 2, 3, 4294967296], 'read_adc_txt:InvalidPayload';
+    [0, 4, 2, 1, 2, 3, 4, 0, 7], 'read_adc_txt:NonZeroTrailer'
+};
+for iCase = 1:size(cases, 1)
+    write_values(fixture, cases{iCase, 1});
+    assert_error_id(@() read_adc_txt(fixture, ioOpts), cases{iCase, 2});
+end
+write_text(fixture, '0,4,2,1,2,3,4,bad');
+assert_error_id(@() read_adc_txt(fixture, ioOpts), 'read_adc_txt:InvalidPayload');
+end
+
+function assert_error_id(callback, expectedId)
+try
+    callback();
+catch err
+    assert(strcmp(err.identifier, expectedId), ...
+        'Expected %s, received %s.', expectedId, err.identifier);
+    return;
+end
+error('test_read_adc_txt_validation:MissingError', 'Expected error %s.', expectedId);
+end
+
+function write_values(filePath, values)
+fid = fopen(filePath, 'w');
+assert(fid >= 0, 'Could not create fixture.');
+cleanupObj = onCleanup(@() fclose(fid)); %#ok<NASGU>
+fprintf(fid, '%.17g', values(1));
+fprintf(fid, ',%.17g', values(2:end));
+fprintf(fid, '\n');
+end
+
+function write_text(filePath, contents)
+fid = fopen(filePath, 'w');
+assert(fid >= 0, 'Could not create fixture.');
+cleanupObj = onCleanup(@() fclose(fid)); %#ok<NASGU>
+fprintf(fid, '%s\n', contents);
+end
+
+function delete_if_exists(filePath)
+if exist(filePath, 'file')
+    delete(filePath);
+end
+end

--- a/community/projects/a100-matlab-adc-signal-processing/functions/read_adc_txt.m
+++ b/community/projects/a100-matlab-adc-signal-processing/functions/read_adc_txt.m
@@ -7,22 +7,46 @@ if fid < 0
     error('Cannot open ADC file: %s', filePath);
 end
 cleanupObj = onCleanup(@() fclose(fid)); %#ok<NASGU>
-dataCell = textscan(fid, '%f', 'Delimiter', ',', 'CollectOutput', true);
-values = dataCell{1};
+tokenCell = textscan(fid, '%s', 'Delimiter', ',');
+values = str2double(tokenCell{1});
 if numel(values) < 4
     error('ADC file is too short: %s', filePath);
 end
 
-header.rx_index = round(values(1));
-header.samples_per_chirp = round(values(2));
-header.chirp_count = round(values(3));
+headerValues = values(1:3);
+if any(~isfinite(headerValues)) || any(headerValues ~= fix(headerValues)) || ...
+        any(abs(headerValues) > flintmax)
+    error('read_adc_txt:InvalidHeader', ...
+        'ADC header fields must be finite, exactly represented integers.');
+end
+
+header.rx_index = headerValues(1);
+header.samples_per_chirp = headerValues(2);
+header.chirp_count = headerValues(3);
 header.file = filePath;
-if mod(header.samples_per_chirp, 2) ~= 0
-    error('samples_per_chirp must be even because two int16 samples share one uint32.');
+if header.rx_index < 0 || header.rx_index > 3
+    error('read_adc_txt:InvalidRxIndex', 'rx_index must be an integer from 0 to 3.');
+end
+if header.samples_per_chirp <= 0 || mod(header.samples_per_chirp, 2) ~= 0
+    error('read_adc_txt:InvalidSamplesPerChirp', ...
+        'samples_per_chirp must be a positive even integer.');
+end
+if header.chirp_count <= 0
+    error('read_adc_txt:InvalidChirpCount', 'chirp_count must be a positive integer.');
 end
 
 expectedWords = header.samples_per_chirp / 2 * header.chirp_count;
+if ~isfinite(expectedWords) || expectedWords ~= fix(expectedWords) || expectedWords > flintmax
+    error('read_adc_txt:InvalidDimensions', ...
+        'Header dimensions produce an invalid packed-word count.');
+end
 payload = values(4:end);
+% uint32 转换会截断或饱和非法输入，必须在转换前拒绝数据损坏。
+if any(~isfinite(payload)) || any(payload ~= fix(payload)) || ...
+        any(payload < 0) || any(payload > double(intmax('uint32')))
+    error('read_adc_txt:InvalidPayload', ...
+        'ADC payload values must be finite uint32 integers.');
+end
 if numel(payload) < expectedWords
     if ioOpts.allow_zero_pad
         warning('ADC payload is short in %s; zero padding %d words.', ...
@@ -35,7 +59,11 @@ if numel(payload) < expectedWords
 end
 trailer = payload(expectedWords+1:end);
 if ~isempty(trailer)
-    fprintf('  %s: ignored %d trailing value(s).\n', ...
+    if any(trailer ~= 0)
+        error('read_adc_txt:NonZeroTrailer', ...
+            'ADC trailer contains non-zero data in %s.', filePath);
+    end
+    fprintf('  %s: verified %d zero padding value(s).\n', ...
         char(filePath), numel(trailer));
 end
 packedWords = uint32(payload(1:expectedWords));

--- a/community/projects/a100-matlab-adc-signal-processing/tests/test_read_adc_txt_validation.m
+++ b/community/projects/a100-matlab-adc-signal-processing/tests/test_read_adc_txt_validation.m
@@ -1,0 +1,69 @@
+function test_read_adc_txt_validation()
+%TEST_READ_ADC_TXT_VALIDATION 验证 ADC token、头部与尾部填充的严格校验。
+
+projectRoot = fileparts(fileparts(mfilename('fullpath')));
+addpath(fullfile(projectRoot, 'functions'));
+fixture = [tempname '.txt'];
+cleanupObj = onCleanup(@() delete_if_exists(fixture)); %#ok<NASGU>
+ioOpts.allow_zero_pad = false;
+
+valid = [0, 4, 2, 1, 2, 3, double(intmax('uint32')), 0, 0];
+write_values(fixture, valid);
+[words, header, trailer] = read_adc_txt(fixture, ioOpts);
+assert(isequal(words(:), uint32(valid(4:7)).'));
+assert(header.rx_index == 0 && header.samples_per_chirp == 4 && header.chirp_count == 2);
+assert(isequal(trailer(:), [0; 0]));
+
+cases = {
+    [Inf, 4, 2, 1, 2, 3, 4], 'read_adc_txt:InvalidHeader';
+    [0.5, 4, 2, 1, 2, 3, 4], 'read_adc_txt:InvalidHeader';
+    [4, 4, 2, 1, 2, 3, 4], 'read_adc_txt:InvalidRxIndex';
+    [0, 3, 2, 1, 2, 3, 4], 'read_adc_txt:InvalidSamplesPerChirp';
+    [0, 4, 0, 1], 'read_adc_txt:InvalidChirpCount';
+    [0, 4294967294, 4294967295, 1], 'read_adc_txt:InvalidDimensions';
+    [0, 4, 2, 1, 2, NaN, 4], 'read_adc_txt:InvalidPayload';
+    [0, 4, 2, 1, 2, 3.5, 4], 'read_adc_txt:InvalidPayload';
+    [0, 4, 2, 1, 2, -1, 4], 'read_adc_txt:InvalidPayload';
+    [0, 4, 2, 1, 2, 3, 4294967296], 'read_adc_txt:InvalidPayload';
+    [0, 4, 2, 1, 2, 3, 4, 0, 7], 'read_adc_txt:NonZeroTrailer'
+};
+for iCase = 1:size(cases, 1)
+    write_values(fixture, cases{iCase, 1});
+    assert_error_id(@() read_adc_txt(fixture, ioOpts), cases{iCase, 2});
+end
+write_text(fixture, '0,4,2,1,2,3,4,bad');
+assert_error_id(@() read_adc_txt(fixture, ioOpts), 'read_adc_txt:InvalidPayload');
+end
+
+function assert_error_id(callback, expectedId)
+try
+    callback();
+catch err
+    assert(strcmp(err.identifier, expectedId), ...
+        'Expected %s, received %s.', expectedId, err.identifier);
+    return;
+end
+error('test_read_adc_txt_validation:MissingError', 'Expected error %s.', expectedId);
+end
+
+function write_values(filePath, values)
+fid = fopen(filePath, 'w');
+assert(fid >= 0, 'Could not create fixture.');
+cleanupObj = onCleanup(@() fclose(fid)); %#ok<NASGU>
+fprintf(fid, '%.17g', values(1));
+fprintf(fid, ',%.17g', values(2:end));
+fprintf(fid, '\n');
+end
+
+function write_text(filePath, contents)
+fid = fopen(filePath, 'w');
+assert(fid >= 0, 'Could not create fixture.');
+cleanupObj = onCleanup(@() fclose(fid)); %#ok<NASGU>
+fprintf(fid, '%s\n', contents);
+end
+
+function delete_if_exists(filePath)
+if exist(filePath, 'file')
+    delete(filePath);
+end
+end

--- a/community/projects/a100-perimeter-vehicle-radar-analysis/functions/common/read_adc_txt.m
+++ b/community/projects/a100-perimeter-vehicle-radar-analysis/functions/common/read_adc_txt.m
@@ -7,22 +7,46 @@ if fid < 0
     error('Cannot open ADC file: %s', filePath);
 end
 cleanupObj = onCleanup(@() fclose(fid)); %#ok<NASGU>
-dataCell = textscan(fid, '%f', 'Delimiter', ',', 'CollectOutput', true);
-values = dataCell{1};
+tokenCell = textscan(fid, '%s', 'Delimiter', ',');
+values = str2double(tokenCell{1});
 if numel(values) < 4
     error('ADC file is too short: %s', filePath);
 end
 
-header.rx_index = round(values(1));
-header.samples_per_chirp = round(values(2));
-header.chirp_count = round(values(3));
+headerValues = values(1:3);
+if any(~isfinite(headerValues)) || any(headerValues ~= fix(headerValues)) || ...
+        any(abs(headerValues) > flintmax)
+    error('read_adc_txt:InvalidHeader', ...
+        'ADC header fields must be finite, exactly represented integers.');
+end
+
+header.rx_index = headerValues(1);
+header.samples_per_chirp = headerValues(2);
+header.chirp_count = headerValues(3);
 header.file = filePath;
-if mod(header.samples_per_chirp, 2) ~= 0
-    error('samples_per_chirp must be even because two int16 samples share one uint32.');
+if header.rx_index < 0 || header.rx_index > 3
+    error('read_adc_txt:InvalidRxIndex', 'rx_index must be an integer from 0 to 3.');
+end
+if header.samples_per_chirp <= 0 || mod(header.samples_per_chirp, 2) ~= 0
+    error('read_adc_txt:InvalidSamplesPerChirp', ...
+        'samples_per_chirp must be a positive even integer.');
+end
+if header.chirp_count <= 0
+    error('read_adc_txt:InvalidChirpCount', 'chirp_count must be a positive integer.');
 end
 
 expectedWords = header.samples_per_chirp / 2 * header.chirp_count;
+if ~isfinite(expectedWords) || expectedWords ~= fix(expectedWords) || expectedWords > flintmax
+    error('read_adc_txt:InvalidDimensions', ...
+        'Header dimensions produce an invalid packed-word count.');
+end
 payload = values(4:end);
+% uint32 转换会截断或饱和非法输入，必须在转换前拒绝数据损坏。
+if any(~isfinite(payload)) || any(payload ~= fix(payload)) || ...
+        any(payload < 0) || any(payload > double(intmax('uint32')))
+    error('read_adc_txt:InvalidPayload', ...
+        'ADC payload values must be finite uint32 integers.');
+end
 if numel(payload) < expectedWords
     if ioOpts.allow_zero_pad
         warning('ADC payload is short in %s; zero padding %d words.', ...
@@ -35,7 +59,11 @@ if numel(payload) < expectedWords
 end
 trailer = payload(expectedWords+1:end);
 if ~isempty(trailer)
-    fprintf('  %s: ignored %d trailing value(s).\n', ...
+    if any(trailer ~= 0)
+        error('read_adc_txt:NonZeroTrailer', ...
+            'ADC trailer contains non-zero data in %s.', filePath);
+    end
+    fprintf('  %s: verified %d zero padding value(s).\n', ...
         char(filePath), numel(trailer));
 end
 packedWords = uint32(payload(1:expectedWords));

--- a/community/projects/a100-perimeter-vehicle-radar-analysis/tests/test_read_adc_txt_validation.m
+++ b/community/projects/a100-perimeter-vehicle-radar-analysis/tests/test_read_adc_txt_validation.m
@@ -1,0 +1,69 @@
+function test_read_adc_txt_validation()
+%TEST_READ_ADC_TXT_VALIDATION 验证 ADC token、头部与尾部填充的严格校验。
+
+projectRoot = fileparts(fileparts(mfilename('fullpath')));
+addpath(fullfile(projectRoot, 'functions', 'common'));
+fixture = [tempname '.txt'];
+cleanupObj = onCleanup(@() delete_if_exists(fixture)); %#ok<NASGU>
+ioOpts.allow_zero_pad = false;
+
+valid = [0, 4, 2, 1, 2, 3, double(intmax('uint32')), 0, 0];
+write_values(fixture, valid);
+[words, header, trailer] = read_adc_txt(fixture, ioOpts);
+assert(isequal(words(:), uint32(valid(4:7)).'));
+assert(header.rx_index == 0 && header.samples_per_chirp == 4 && header.chirp_count == 2);
+assert(isequal(trailer(:), [0; 0]));
+
+cases = {
+    [Inf, 4, 2, 1, 2, 3, 4], 'read_adc_txt:InvalidHeader';
+    [0.5, 4, 2, 1, 2, 3, 4], 'read_adc_txt:InvalidHeader';
+    [4, 4, 2, 1, 2, 3, 4], 'read_adc_txt:InvalidRxIndex';
+    [0, 3, 2, 1, 2, 3, 4], 'read_adc_txt:InvalidSamplesPerChirp';
+    [0, 4, 0, 1], 'read_adc_txt:InvalidChirpCount';
+    [0, 4294967294, 4294967295, 1], 'read_adc_txt:InvalidDimensions';
+    [0, 4, 2, 1, 2, NaN, 4], 'read_adc_txt:InvalidPayload';
+    [0, 4, 2, 1, 2, 3.5, 4], 'read_adc_txt:InvalidPayload';
+    [0, 4, 2, 1, 2, -1, 4], 'read_adc_txt:InvalidPayload';
+    [0, 4, 2, 1, 2, 3, 4294967296], 'read_adc_txt:InvalidPayload';
+    [0, 4, 2, 1, 2, 3, 4, 0, 7], 'read_adc_txt:NonZeroTrailer'
+};
+for iCase = 1:size(cases, 1)
+    write_values(fixture, cases{iCase, 1});
+    assert_error_id(@() read_adc_txt(fixture, ioOpts), cases{iCase, 2});
+end
+write_text(fixture, '0,4,2,1,2,3,4,bad');
+assert_error_id(@() read_adc_txt(fixture, ioOpts), 'read_adc_txt:InvalidPayload');
+end
+
+function assert_error_id(callback, expectedId)
+try
+    callback();
+catch err
+    assert(strcmp(err.identifier, expectedId), ...
+        'Expected %s, received %s.', expectedId, err.identifier);
+    return;
+end
+error('test_read_adc_txt_validation:MissingError', 'Expected error %s.', expectedId);
+end
+
+function write_values(filePath, values)
+fid = fopen(filePath, 'w');
+assert(fid >= 0, 'Could not create fixture.');
+cleanupObj = onCleanup(@() fclose(fid)); %#ok<NASGU>
+fprintf(fid, '%.17g', values(1));
+fprintf(fid, ',%.17g', values(2:end));
+fprintf(fid, '\n');
+end
+
+function write_text(filePath, contents)
+fid = fopen(filePath, 'w');
+assert(fid >= 0, 'Could not create fixture.');
+cleanupObj = onCleanup(@() fclose(fid)); %#ok<NASGU>
+fprintf(fid, '%s\n', contents);
+end
+
+function delete_if_exists(filePath)
+if exist(filePath, 'file')
+    delete(filePath);
+end
+end


### PR DESCRIPTION
## 范围

直接实施集中清单 #54 的候选 1，仅修改三个现有 Community Project 的 ADC 文本读取器及对应回归测试。

## 修改

- 按字符串 token 完整读取输入，避免坏 token 使数值扫描提前停止。
- 严格验证 Rx、samples per chirp、chirp count 和 packed-word 计数。
- 在转为 uint32 前拒绝 NaN、无穷、小数、负数和溢出 payload。
- trailer 只允许全零 padding；非零尾部明确报错。
- 保留 allow_zero_pad 的短 payload 兼容行为。
- 三个项目各增加独立的输入校验回归测试。

## 本地验证

- 三份生产实现逐字一致。
- 三份真实 ADC 文件均核验为 0,1024,256 头、131072 个合法 payload word 和 1 个全零 trailer。
- 静态块结构检查通过。
- git diff --check 通过。
- 范围门禁：6 文件，新增 315 行、删除 24 行，共 339/400 行。

## 未运行

本机无 MATLAB/Octave，新增 test_read_adc_txt_validation.m 未实际执行；未运行完整实测处理链或硬件采集。

Refs #54