### PR TITLE
fix(community): handle periodic Doppler boundaries

### DIFF
--- a/community/projects/a100-matlab-adc-signal-processing/functions/cfar_2d.m
+++ b/community/projects/a100-matlab-adc-signal-processing/functions/cfar_2d.m
@@ -5,14 +5,13 @@ trainD = cfarOpts.training_cells(2);
 guardR = cfarOpts.guard_cells(1);
 guardD = cfarOpts.guard_cells(2);
 halfR = trainR + guardR;
-halfD = trainD + guardD;
 algorithm = upper(strtrim(cfarOpts.algorithm));
 
 switch algorithm
     case 'CA'
         [kernel, ~, ~] = build_cfar_kernels(trainR, trainD, guardR, guardD);
         numTraining = sum(kernel(:));
-        noiseMap = conv2(powerMap, kernel, 'same') / numTraining;
+        noiseMap = conv2_doppler_periodic(powerMap, kernel) / numTraining;
         alpha = cfar_alpha_ca(numTraining, cfarOpts.pfa);
         thresholdMap = alpha * noiseMap;
         mask = powerMap > thresholdMap;
@@ -69,8 +68,9 @@ switch algorithm
         error('Unsupported CFAR algorithm: %s', cfarOpts.algorithm);
 end
 
+% Doppler FFT 栅格是周期域；仅 Range 边界缺少完整训练窗。
 valid = false(size(powerMap));
-valid(halfR+1:end-halfR, halfD+1:end-halfD) = true;
+valid(halfR+1:end-halfR, :) = true;
 mask = mask & valid;
 methodMap(~valid) = 0;
 
@@ -83,7 +83,7 @@ result.snr_db = 10 * log10((powerMap + eps) ./ (noiseMap + eps));
 result.alpha = alpha;
 result.alpha_map = alphaMap;
 result.num_training_cells = numTrainingMap;
-result.edge_margin = [halfR, halfD];
+result.edge_margin = [halfR, 0];
 result.method_map = methodMap;
 result.method_names = methodNames;
 result.variability_index = variabilityIndex;
@@ -91,8 +91,8 @@ result.sector_mean_ratio = sectorMeanRatio;
 end
 
 function variabilityIndex = local_variability_index(powerMap, kernel, numTraining)
-localSum = conv2(powerMap, kernel, 'same');
-localSumSq = conv2(powerMap.^2, kernel, 'same');
+localSum = conv2_doppler_periodic(powerMap, kernel);
+localSumSq = conv2_doppler_periodic(powerMap.^2, kernel);
 localMean = localSum / numTraining;
 localVariance = max(localSumSq / numTraining - localMean.^2, 0);
 variabilityIndex = localVariance ./ (localMean.^2 + eps);

--- a/community/projects/a100-matlab-adc-signal-processing/functions/conv2_doppler_periodic.m
+++ b/community/projects/a100-matlab-adc-signal-processing/functions/conv2_doppler_periodic.m
@@ -1,0 +1,10 @@
+function result = conv2_doppler_periodic(data, kernel)
+%CONV2_DOPPLER_PERIODIC 仅在 Doppler 维周期延拓后执行二维卷积。
+% Range 维仍使用 conv2 的零填充边界，避免把不同距离端点相连。
+halfD = floor(size(kernel,2) / 2);
+numDoppler = size(data,2);
+wrappedDoppler = mod((-halfD:numDoppler+halfD-1), numDoppler) + 1;
+padded = data(:, wrappedDoppler);
+convolved = conv2(padded, kernel, 'same');
+result = convolved(:, halfD+(1:numDoppler));
+end

--- a/community/projects/a100-matlab-adc-signal-processing/functions/estimate_angles_for_detections.m
+++ b/community/projects/a100-matlab-adc-signal-processing/functions/estimate_angles_for_detections.m
@@ -38,7 +38,8 @@ for iDetection = 1:height(detections)
     rHalf = angleOpts.music_snapshot_half_window(1);
     dHalf = angleOpts.music_snapshot_half_window(2);
     rIdx = max(1,r-rHalf):min(size(rdCube,1),r+rHalf);
-    dIdx = max(1,d-dHalf):min(size(rdCube,2),d+dHalf);
+    % MUSIC 快拍的 Doppler 邻域采用周期索引，Range 邻域保持截断。
+    dIdx = mod((d-dHalf:d+dHalf)-1, size(rdCube,2)) + 1;
     localData = permute(rdCube(rIdx,dIdx,:), [3,1,2]);
     localSnapshots = reshape(localData, numChannels, []);
     localSnapshots = calibrate_angle_snapshots(localSnapshots, ...

--- a/community/projects/a100-matlab-adc-signal-processing/functions/extract_detections.m
+++ b/community/projects/a100-matlab-adc-signal-processing/functions/extract_detections.m
@@ -18,7 +18,8 @@ peakHalfD = detOpts.local_peak_half_window(2);
 for i = 1:numel(rowList)
     r = rowList(i); d = colList(i);
     rIdx = max(1,r-peakHalfR):min(size(powerMap,1),r+peakHalfR);
-    dIdx = max(1,d-peakHalfD):min(size(powerMap,2),d+peakHalfD);
+    % Doppler 首尾相邻，局部峰值窗口必须跨 FFT 端点比较。
+    dIdx = mod((d-peakHalfD:d+peakHalfD)-1, size(powerMap,2)) + 1;
     patch = powerMap(rIdx, dIdx);
     keep(i) = powerMap(r,d) >= max(patch(:));
 end

--- a/community/projects/a100-matlab-adc-signal-processing/functions/os_cfar_map.m
+++ b/community/projects/a100-matlab-adc-signal-processing/functions/os_cfar_map.m
@@ -22,12 +22,16 @@ noiseMap = nan(size(powerMap));
 thresholdMap = nan(size(powerMap));
 mask = false(size(powerMap));
 
+numDoppler = size(powerMap,2);
 for iRange = halfR+1:size(powerMap,1)-halfR
-    for iDoppler = halfD+1:size(powerMap,2)-halfD
+    for iDoppler = 1:numDoppler
         training = zeros(numTraining, 1);
         for iCell = 1:numTraining
+            % Doppler 训练单元跨越 FFT 端点时按周期索引取样。
+            trainingDoppler = mod(iDoppler + offsets(iCell,2) - 1, ...
+                numDoppler) + 1;
             training(iCell) = powerMap(iRange + offsets(iCell,1), ...
-                iDoppler + offsets(iCell,2));
+                trainingDoppler);
         end
         training = sort(training, 'ascend');
         noiseValue = training(rankIndex);

--- a/community/projects/a100-matlab-adc-signal-processing/functions/sector_cfar_map.m
+++ b/community/projects/a100-matlab-adc-signal-processing/functions/sector_cfar_map.m
@@ -7,8 +7,8 @@ function [mask, noiseMap, thresholdMap, alphaMap, numTrainingMap, ...
 numSectors = size(sectorKernels,3);
 sectorMeans = zeros([size(powerMap), numSectors]);
 for iSector = 1:numSectors
-    sectorMeans(:,:,iSector) = conv2(powerMap, ...
-        sectorKernels(:,:,iSector), 'same') / sectorCounts(iSector);
+    sectorMeans(:,:,iSector) = conv2_doppler_periodic(powerMap, ...
+        sectorKernels(:,:,iSector)) / sectorCounts(iSector);
 end
 
 switch upper(mode)

--- a/community/projects/a100-matlab-adc-signal-processing/functions/vi_cfar_map.m
+++ b/community/projects/a100-matlab-adc-signal-processing/functions/vi_cfar_map.m
@@ -18,8 +18,10 @@ sectorMeans = zeros([size(powerMap), numSectors]);
 sectorVariability = zeros([size(powerMap), numSectors]);
 sectorSums = zeros([size(powerMap), numSectors]);
 for iSector = 1:numSectors
-    localSum = conv2(powerMap, sectorKernels(:,:,iSector), 'same');
-    localSumSq = conv2(powerMap.^2, sectorKernels(:,:,iSector), 'same');
+    localSum = conv2_doppler_periodic(powerMap, ...
+        sectorKernels(:,:,iSector));
+    localSumSq = conv2_doppler_periodic(powerMap.^2, ...
+        sectorKernels(:,:,iSector));
     localMean = localSum / sectorCounts(iSector);
     localVar = max(localSumSq / sectorCounts(iSector) - localMean.^2, 0);
     sectorSums(:,:,iSector) = localSum;
@@ -27,8 +29,8 @@ for iSector = 1:numSectors
     sectorVariability(:,:,iSector) = localVar ./ (localMean.^2 + eps);
 end
 
-fullSum = conv2(powerMap, fullKernel, 'same');
-fullSumSq = conv2(powerMap.^2, fullKernel, 'same');
+fullSum = conv2_doppler_periodic(powerMap, fullKernel);
+fullSumSq = conv2_doppler_periodic(powerMap.^2, fullKernel);
 fullMean = fullSum / numTraining;
 fullVar = max(fullSumSq / numTraining - fullMean.^2, 0);
 variabilityIndex = fullVar ./ (fullMean.^2 + eps);

--- a/community/projects/a100-matlab-adc-signal-processing/tests/run_doppler_boundary_tests.m
+++ b/community/projects/a100-matlab-adc-signal-processing/tests/run_doppler_boundary_tests.m
@@ -1,0 +1,138 @@
+function run_doppler_boundary_tests()
+%RUN_DOPPLER_BOUNDARY_TESTS 验证 Doppler 周期边界在检测链中的一致语义。
+testDir = fileparts(mfilename('fullpath'));
+projectRoot = fileparts(testDir);
+addpath(genpath(fullfile(projectRoot, 'functions')));
+
+% 卷积仅环绕 Doppler；Range 端点仍使用零填充。
+assert(isequal(conv2_doppler_periodic([1,2,3,4], [1,0,1]), ...
+    [6,4,6,4]));
+assert(isequal(conv2_doppler_periodic([1;2;3], [1;0;1]), ...
+    [2;4;2]));
+
+test_cfar_shift_equivariance();
+test_local_peak_wraps();
+test_music_snapshots_wrap();
+fprintf('All Doppler boundary tests passed.\n');
+end
+
+function test_cfar_shift_equivariance()
+powerMap = reshape(mod((1:13*12) * 17, 101) + 1, 13, 12);
+opts.training_cells = [1, 2];
+opts.guard_cells = [1, 1];
+opts.pfa = 1e-3;
+opts.os_rank_ratio = 0.75;
+opts.vi_threshold = 2.5;
+opts.mean_ratio_threshold = 2.8;
+opts.min_homogeneous_sectors = 1;
+algorithms = {'CA','OS','GOCA','SOCA','VI'};
+shift = 3;
+fields = {'mask','noise','threshold','snr_db','alpha_map', ...
+    'num_training_cells','method_map','variability_index', ...
+    'sector_mean_ratio'};
+
+for iAlgorithm = 1:numel(algorithms)
+    opts.algorithm = algorithms{iAlgorithm};
+    original = cfar_2d(powerMap, opts);
+    shifted = cfar_2d(circshift(powerMap, [0, shift]), opts);
+    assert(isequal(original.edge_margin, [2, 0]));
+    edgeMethods = original.method_map(3:end-2, [1,end]);
+    assert(all(edgeMethods(:) > 0));
+    for iField = 1:numel(fields)
+        expected = circshift(original.(fields{iField}), [0, shift]);
+        assert_close(shifted.(fields{iField}), expected);
+    end
+end
+end
+
+function test_local_peak_wraps()
+numRange = 5;
+numDoppler = 8;
+powerMap = ones(numRange, numDoppler);
+powerMap(3,1) = 10;
+powerMap(3,end) = 20;
+cfarResult.mask = false(numRange, numDoppler);
+cfarResult.mask(3,[1,end]) = true;
+cfarResult.power = powerMap;
+cfarResult.noise = ones(size(powerMap));
+cfarResult.threshold = ones(size(powerMap));
+cfarResult.algorithm = 'CA';
+cfarResult.method_map = ones(size(powerMap), 'uint8');
+cfarResult.method_names = {'INVALID','CA'};
+cfarResult.variability_index = zeros(size(powerMap));
+cfarResult.sector_mean_ratio = ones(size(powerMap));
+
+cfg.range_axis_m = 0:numRange-1;
+cfg.velocity_axis_mps = 1:numDoppler;
+cfg.max_range_m = cfg.range_axis_m(end);
+opts.min_range_m = 0;
+opts.max_range_m = inf;
+opts.zero_doppler_exclusion_bins = 0;
+opts.local_peak_half_window = [0, 1];
+opts.min_separation_bins = [0, 0];
+opts.min_snr_db = -inf;
+opts.max_detections = 8;
+detections = extract_detections(cfarResult, cfg, opts);
+assert(height(detections) == 1);
+assert(detections.DopplerBin == numDoppler);
+end
+
+function test_music_snapshots_wrap()
+numRange = 3;
+numDoppler = 8;
+numChannels = 4;
+rdCube = complex(zeros(numRange, numDoppler, numChannels));
+for iRange = 1:numRange
+    for iDoppler = 1:numDoppler
+        for iChannel = 1:numChannels
+            phase = 0.13*iRange + 0.31*iDoppler*iChannel;
+            rdCube(iRange,iDoppler,iChannel) = ...
+                (iRange + iDoppler/10) * exp(1i*phase);
+        end
+    end
+end
+
+cfg.virtual_array.positions_lambda = (0:numChannels-1).' * 0.5;
+cfg.virtual_array.phase_error_deg = zeros(numChannels,1);
+opts.grid_deg = -60:2:60;
+opts.grid_step_deg = 2;
+opts.apply_phase_calibration = true;
+opts.fft_size = 64;
+opts.fft_grid_spacing_lambda = 0.5;
+opts.music_signal_count = 1;
+opts.music_snapshot_half_window = [1, 1];
+opts.music_diagonal_loading = 1e-3;
+opts.omp_max_sources = 1;
+opts.selected_method = 'MUSIC';
+
+detection = table(2, 1, 1, 0, ...
+    'VariableNames', {'RangeBin','DopplerBin','Range_m','Velocity_mps'});
+[anglesAtEdge, edgeDiagnostics] = estimate_angles_for_detections( ...
+    rdCube, detection, cfg, opts);
+shift = 3;
+detection.DopplerBin = 1 + shift;
+[anglesInside, insideDiagnostics] = estimate_angles_for_detections( ...
+    circshift(rdCube, [0, shift, 0]), detection, cfg, opts);
+
+angleFields = {'AngleFFT_deg','DML_deg','MUSIC_deg','OMP_deg', ...
+    'SelectedAngle_deg'};
+for iField = 1:numel(angleFields)
+    assert_close(anglesAtEdge.(angleFields{iField}), ...
+        anglesInside.(angleFields{iField}));
+end
+assert_close(edgeDiagnostics.music_spectrum, ...
+    insideDiagnostics.music_spectrum);
+end
+
+function assert_close(actual, expected)
+assert(isequal(size(actual), size(expected)));
+assert(isequal(isnan(actual), isnan(expected)));
+finite = ~isnan(actual) & ~isinf(actual) & ...
+    ~isnan(expected) & ~isinf(expected);
+if any(finite(:))
+    scale = max(1, max(abs(expected(finite))));
+    assert(max(abs(double(actual(finite)) - double(expected(finite)))) ...
+        <= 1e-10 * scale);
+end
+assert(isequal(isinf(actual), isinf(expected)));
+end


### PR DESCRIPTION
## 范围

直接实施集中清单 #54 的候选 5，仅修改现有 a100-matlab-adc-signal-processing Community Project。开放 PR #49 位于另一个新项目目录，本 PR 与其没有文件重叠。

## 修改

- CA、OS、GOCA、SOCA、VI-CFAR 的 Doppler 训练窗统一周期环绕。
- Range 维继续使用非周期边界。
- CFAR 有效区只裁剪 Range，保留 Doppler 首尾。
- 局部峰值窗口和 MUSIC snapshot 同步使用周期 Doppler 索引。
- 新增周期卷积 helper 和五类 CFAR、峰值、MUSIC 边界回归。

## 本地验证

- 周期卷积和 Range 有效区公式检查通过。
- 静态调用链确认各 CFAR 算法均使用周期训练数据。
- git diff --check 通过。
- 范围门禁：8 文件，新增 172 行、删除 16 行，共 188/400 行。

## 未运行

本机无 MATLAB/Octave，run_doppler_boundary_tests.m 未实际执行；需维护者环境核验五类 CFAR 数值结果。

Refs #54