### PR TITLE
fix(community): preserve target timing and manifest integrity

### DIFF
--- a/community/projects/a100-indoor-cart-mti/src/read_radartools_targets.m
+++ b/community/projects/a100-indoor-cart-mti/src/read_radartools_targets.m
@@ -42,7 +42,7 @@ end
 capacity = 4096;
 frame_nb = nan(capacity, 1);
 frame_sequence = nan(capacity, 1);
-time_of_day_s = nan(capacity, 1);
+timestamp_ms = nan(capacity, 1);
 obj_id = nan(capacity, 1);
 range_m = nan(capacity, 1);
 speed_mps = nan(capacity, 1);
@@ -59,26 +59,30 @@ count = 0;
 ignored_lines = 0;
 current_frame = NaN;
 current_frame_sequence = -1;
-current_time_s = NaN;
+current_timestamp_ms = NaN;
+total_frame_count = 0;
 line = fgetl(fid);
 while ischar(line)
     start_token = regexp(line, '^START,FrameNb:([0-9]+)', 'tokens', 'once');
     if ~isempty(start_token)
         current_frame = str2double(start_token{1});
         current_frame_sequence = current_frame_sequence + 1;
-        current_time_s = NaN;
+        current_timestamp_ms = NaN;
+        total_frame_count = total_frame_count + 1;
         line = fgetl(fid);
         continue;
     end
 
     timestamp_token = regexp(line, ...
-        '^[0-9]{4}/[0-9]{2}/[0-9]{2} ([0-9]{2}):([0-9]{2}):([0-9]{2}):([0-9]{3})', ...
+        '^([0-9]{4})/([0-9]{2})/([0-9]{2}) ([0-9]{2}):([0-9]{2}):([0-9]{2}):([0-9]{3})', ...
         'tokens', 'once');
     if ~isempty(timestamp_token)
-        current_time_s = str2double(timestamp_token{1}) * 3600 + ...
-                         str2double(timestamp_token{2}) * 60 + ...
-                         str2double(timestamp_token{3}) + ...
-                         str2double(timestamp_token{4}) / 1000;
+        timestamp_values = cellfun(@str2double, timestamp_token);
+        day_index = round(datenum(timestamp_values(1), timestamp_values(2), ...
+            timestamp_values(3)) - datenum(1970, 1, 1));
+        current_timestamp_ms = (((day_index * 24 + timestamp_values(4)) * 60 + ...
+            timestamp_values(5)) * 60 + timestamp_values(6)) * 1000 + ...
+            timestamp_values(7);
         line = fgetl(fid);
         continue;
     end
@@ -109,7 +113,7 @@ while ischar(line)
         capacity = capacity * 2;
         frame_nb(old_capacity + 1:capacity, 1) = NaN;
         frame_sequence(old_capacity + 1:capacity, 1) = NaN;
-        time_of_day_s(old_capacity + 1:capacity, 1) = NaN;
+        timestamp_ms(old_capacity + 1:capacity, 1) = NaN;
         obj_id(old_capacity + 1:capacity, 1) = NaN;
         range_m(old_capacity + 1:capacity, 1) = NaN;
         speed_mps(old_capacity + 1:capacity, 1) = NaN;
@@ -125,7 +129,7 @@ while ischar(line)
 
     frame_nb(count) = current_frame;
     frame_sequence(count) = current_frame_sequence;
-    time_of_day_s(count) = current_time_s;
+    timestamp_ms(count) = current_timestamp_ms;
     obj_id(count) = key_values(1);
     range_m(count) = key_values(2);
     speed_mps(count) = key_values(3);
@@ -142,24 +146,29 @@ while ischar(line)
 end
 clear cleanup;
 
-fields_to_trim = {'frame_nb', 'frame_sequence', 'time_of_day_s', 'obj_id', ...
+fields_to_trim = {'frame_nb', 'frame_sequence', 'timestamp_ms', 'obj_id', ...
                   'range_m', 'speed_mps', 'angle_deg', 'snr_db', 'x_m', 'y_m', ...
                   'estimated_speed_mps', 'rcs_dbsm', 'reliability', ...
                   'obstacle_probability'};
-values = {frame_nb, frame_sequence, time_of_day_s, obj_id, range_m, speed_mps, ...
+values = {frame_nb, frame_sequence, timestamp_ms, obj_id, range_m, speed_mps, ...
           angle_deg, snr_db, x_m, y_m, estimated_speed_mps, rcs_dbsm, ...
           reliability, obstacle_probability};
 targets = struct();
 for idx = 1:numel(fields_to_trim)
     targets.(fields_to_trim{idx}) = values{idx}(1:count);
 end
-targets.elapsed_s = elapsed_seconds(targets.time_of_day_s, targets.frame_sequence);
+% 毫秒整数先做差，避免大绝对时间戳相减造成亚秒精度损失。
+targets.timestamp_s = targets.timestamp_ms / 1000;
+targets.time_of_day_s = mod(targets.timestamp_ms, 86400000) / 1000;
+targets.elapsed_s = elapsed_seconds(targets.timestamp_ms);
 targets.polar_x_m = -targets.range_m .* sin(targets.angle_deg * pi / 180);
 targets.polar_y_m = targets.range_m .* cos(targets.angle_deg * pi / 180);
 targets.meta = struct('file', file_path, ...
                       'record_count', count, ...
                       'ignored_line_count', ignored_lines, ...
-                      'frame_count', numel(unique(targets.frame_sequence)), ...
+                      'frame_count', total_frame_count, ...
+                      'target_frame_count', ...
+                          numel(unique(targets.frame_sequence)), ...
                       'headers', {headers});
 end
 
@@ -183,17 +192,12 @@ else
 end
 end
 
-function elapsed = elapsed_seconds(time_of_day_s, frame_sequence)
-elapsed = nan(size(time_of_day_s));
-valid = isfinite(time_of_day_s);
+function elapsed = elapsed_seconds(timestamp_ms)
+elapsed = nan(size(timestamp_ms));
+valid = isfinite(timestamp_ms);
 if any(valid)
-    start_time = min(time_of_day_s(valid));
-    elapsed(valid) = time_of_day_s(valid) - start_time;
-    missing = ~valid;
-    if any(missing)
-        elapsed(missing) = frame_sequence(missing) - min(frame_sequence);
-    end
-else
-    elapsed = frame_sequence - min(frame_sequence);
+    valid_indices = find(valid);
+    start_time_ms = timestamp_ms(valid_indices(1));
+    elapsed(valid) = (timestamp_ms(valid) - start_time_ms) / 1000;
 end
 end

--- a/community/projects/a100-indoor-cart-mti/src/verify_data_manifest.m
+++ b/community/projects/a100-indoor-cart-mti/src/verify_data_manifest.m
@@ -25,6 +25,7 @@ hash_column = required_column(headers, 'sha256');
 
 entry_count = 0;
 total_bytes = 0;
+seen_paths = {};
 line_number = 1;
 line = fgetl(fid);
 while ischar(line)
@@ -44,6 +45,11 @@ while ischar(line)
     expected_size = str2double(strtrim(fields{size_column}));
     expected_hash = lower(strtrim(fields{hash_column}));
     validate_relative_path(relative_path, line_number);
+    if any(strcmp(seen_paths, relative_path))
+        error('a100:DuplicateManifestPath', ...
+            'Manifest line %d repeats path "%s".', line_number, relative_path);
+    end
+    seen_paths{end + 1} = relative_path; %#ok<AGROW>
     if ~isfinite(expected_size) || expected_size < 0 || expected_size ~= floor(expected_size)
         error('a100:InvalidManifestSize', ...
             'Manifest line %d has invalid size "%s".', line_number, fields{size_column});

--- a/community/projects/a100-indoor-cart-mti/tests/test_manifest.m
+++ b/community/projects/a100-indoor-cart-mti/tests/test_manifest.m
@@ -23,8 +23,23 @@ assert(fixture_report.total_bytes == 3);
 write_bytes(data_path, uint8('abd'));
 assert_error_id(@() verify_data_manifest(fixture_root), 'a100:ManifestHashMismatch');
 
+write_bytes(data_path, uint8('abc'));
+write_duplicate_manifest(manifest_path, 3, ...
+    'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad');
+assert_error_id(@() verify_data_manifest(fixture_root), 'a100:DuplicateManifestPath');
+
 clear cleanup;
 remove_fixture(fixture_root);
+end
+
+function write_duplicate_manifest(file_path, size_bytes, digest)
+fid = fopen(file_path, 'w');
+assert(fid >= 0);
+cleanup = onCleanup(@() fclose(fid));
+fprintf(fid, 'relative_path,size_bytes,sha256\n');
+fprintf(fid, 'data/sample.txt,%d,%s\n', size_bytes, digest);
+fprintf(fid, 'data/sample.txt,%d,%s\n', size_bytes, digest);
+clear cleanup;
 end
 
 function write_manifest(file_path, size_bytes, digest)

--- a/community/projects/a100-indoor-cart-mti/tests/test_target_parser.m
+++ b/community/projects/a100-indoor-cart-mti/tests/test_target_parser.m
@@ -19,11 +19,37 @@ fclose(fid);
 targets = read_radartools_targets(fixture);
 assert(targets.meta.record_count == 2);
 assert(targets.meta.frame_count == 2);
+assert(targets.meta.target_frame_count == 2);
 assert(isequal(targets.frame_nb, [7; 8]));
 assert(abs(targets.elapsed_s(2) - 0.060) < 1e-9);
 assert(all(targets.obj_id == 4));
 assert(abs(targets.polar_y_m(1) - 7.275) < 0.01);
 assert(targets.reliability(1) == 98);
+
+% 完整日期必须保证跨午夜时间仍单调；空帧也应计入检测率分母。
+midnight_fixture = [tempname '.csv'];
+midnight_cleanup = onCleanup(@() delete_if_exists(midnight_fixture));
+fid = fopen(midnight_fixture, 'w');
+assert(fid >= 0);
+fprintf(fid, ['ObjId,range,speed,angle,snr,Kstate,OboCarSpeed,heigh,heighAngle,' ...
+              'X,Y,EstimateCarSpeed,EstimateMagCarSpeed,RCS,trkReiablility,ObstacleProb\n']);
+fprintf(fid, 'START,FrameNb:20,CameraNb:0\n');
+fprintf(fid, '2026/08/02 23:59:59:900---->\n');
+fprintf(fid, '4,7.28,-0.25,-2.07,12,0,0,0,0,0.263,7.275,-0.25,0,-6.3,98,99\n');
+fprintf(fid, 'START,FrameNb:21,CameraNb:0\n');
+fprintf(fid, '2026/08/03 00:00:00:100---->\n');
+fprintf(fid, '4,7.20,-0.25,-2.10,13,0,0,0,0,0.264,7.195,-0.25,0,-6.1,98,99\n');
+fprintf(fid, 'START,FrameNb:22,CameraNb:0\n');
+fprintf(fid, 'START,FrameNb:23,CameraNb:0\n');
+fprintf(fid, '4,7.10,-0.25,-2.10,13,0,0,0,0,0.264,7.095,-0.25,0,-6.1,98,99\n');
+fclose(fid);
+
+midnight_targets = read_radartools_targets(midnight_fixture);
+assert(midnight_targets.meta.record_count == 3);
+assert(midnight_targets.meta.frame_count == 4);
+assert(midnight_targets.meta.target_frame_count == 3);
+assert(abs(midnight_targets.elapsed_s(2) - 0.200) < 1e-4);
+assert(isnan(midnight_targets.elapsed_s(3)));
 
 synthetic = targets;
 synthetic.speed_mps = [-0.2; -0.2];
@@ -52,6 +78,8 @@ assert(strcmp(track.inferred_direction, 'unknown'));
 
 clear cleanup;
 delete_if_exists(fixture);
+clear midnight_cleanup;
+delete_if_exists(midnight_fixture);
 end
 
 function delete_if_exists(file_path)


### PR DESCRIPTION
## 范围

直接实施集中清单 #54 的候选 6–7，仅修改 a100-indoor-cart-mti Community Project。

## 修改

- 解析完整日期与毫秒时间戳，跨午夜 elapsed 保持单调。
- 缺失时间戳保留 NaN，不再把帧序号伪造成秒数。
- frame_count 统计全部 START 帧，包括空帧；target_frame_count 保留含目标帧数量。
- stationary ROI 检测率因而使用完整帧数分母。
- manifest 对规范化 relative_path 做唯一性校验，重复路径明确报错。
- 回归覆盖跨午夜、空帧、缺时间戳和重复 manifest。

## 本地验证

- 真实 RawTarget 文件的 START 帧数量完成静态核对。
- 真实 manifest 保持 31 条记录，既有大小与哈希验证逻辑不变。
- git diff --check 通过。
- 范围门禁：4 文件，新增 78 行、删除 25 行，共 103/400 行。

## 未运行

本机无 MATLAB/Octave，项目 run_tests.m 未实际执行；未重新生成 target metrics 与图表。

Refs #54